### PR TITLE
Increase stack size

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -124,5 +124,5 @@ void app_main(void) {
 	ESP_ERROR_CHECK(esp_wifi_start());
 	ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
 
-	xTaskCreate(&spam_task, "spam_task", 2048, NULL, 5, NULL);
+	xTaskCreate(&spam_task, "spam_task", 4096, NULL, 5, NULL);
 }


### PR DESCRIPTION
The stack size of the task was just barely big enough as is; adding a log print made it unreliable and caused it to sometimes corrupt the stack. I doubled the size of the stack and added a logging print statement. After 1 hour of running, the maximum free stack space is now 2044 bytes (if the previous stack size of 2048 bytes was used, we'd be 4 bytes short).